### PR TITLE
Admin add tutorial tyla

### DIFF
--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -11,59 +11,55 @@
     <% end %>
   </ul>
 </div>
-
-<div class="col col-8">
-  <div class="title-bookmark">
-    <h3><%= @facade.current_video.title %></h3>
-    <div class="bookmarks-btn">
-      <% if current_user %>
-      <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
-      <% else %>
-      <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
-      <% end %>
+<%if @facade.current_video %>
+  <div class="col col-8">
+    <div class="title-bookmark">
+      <h3><%= @facade.current_video.title %></h3>
+      <div class="bookmarks-btn">
+        <% if current_user %>
+        <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
+        <% else %>
+        <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
+        <% end %>
+      </div>
     </div>
-  </div>
-
-  <div id="player">
-    <script src="https://www.youtube.com/player_api"></script>
-    <script>
-    // create youtube player
-    var player;
-    var position;
-    function onYouTubePlayerAPIReady() {
-      player = new YT.Player('player', {
-        width: '640',
-        height: '390',
-        videoId: '<%= @facade.current_video.video_id %>',
-        events: {
-          onReady: onPlayerReady,
-          onStateChange: onPlayerStateChange
-        }
-      });
-    }
-
-    // autoplay video
-    function onPlayerReady(event) {
-      event.target.playVideo();
-    }
-
-    // when video ends
-    function onPlayerStateChange(event) {
-      if(event.data === 0 && <%= @facade.play_next_video? %>) {
-        window.location = "/tutorials/<%=@facade.id%>?video_id=<%=@facade.next_video.id %>";
-      } else if(event.data === 0 && <%= @facade.play_next_video? == false %>) {
-        const message = document.querySelector(`#message`);
-        message.innerHTML = "You watched them all. Bask in the glory of your new skills."
+    <div id="player">
+      <script src="https://www.youtube.com/player_api"></script>
+      <script>
+      // create youtube player
+      var player;
+      var position;
+      function onYouTubePlayerAPIReady() {
+        player = new YT.Player('player', {
+          width: '640',
+          height: '390',
+          videoId: '<%= @facade.current_video.video_id %>',
+          events: {
+            onReady: onPlayerReady,
+            onStateChange: onPlayerStateChange
+          }
+        });
       }
-    }
-  </script>
-</div>
-
+      // autoplay video
+      function onPlayerReady(event) {
+        event.target.playVideo();
+      }
+      // when video ends
+      function onPlayerStateChange(event) {
+        if(event.data === 0 && <%= @facade.play_next_video? %>) {
+          window.location = "/tutorials/<%=@facade.id%>?video_id=<%=@facade.next_video.id %>";
+        } else if(event.data === 0 && <%= @facade.play_next_video? == false %>) {
+          const message = document.querySelector(`#message`);
+          message.innerHTML = "You watched them all. Bask in the glory of your new skills."
+        }
+      }
+      </script>
+    </div>
   <h4>Description</h4>
   <p data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
     <%= @facade.current_video.description.truncate(50) %>...
     <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
   </p>
-</div>
-
+  </div>
+<% end %>
 </main>

--- a/spec/features/admin/can_add_tutorials_spec.rb
+++ b/spec/features/admin/can_add_tutorials_spec.rb
@@ -6,23 +6,17 @@ describe "As a logged in admin" do
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
-      visit "/admin/dashboard"
-
-      click_on "New Tutorial"
-
-      expect(current_path).to eq(new_admin_tutorial_path)
+      visit "/admin/tutorials/new"
 
       fill_in "Title", with: "How to learn in a new way"
       fill_in "Description", with: "Relearning for long term success"
       fill_in "Thumbnail", with: "https://i.ytimg.com/vi/qMkRHW9zE1c/hqdefault.jpg"
-
+      
       click_on "Save"
 
       tutorial = Tutorial.last
-
-      expect(current_path).to eq(tutorial_path)
-      expect(page).to have_content(tutorial.name)
-      expect(page).to have_content(tutorial.description)
+      expect(current_path).to eq("/tutorials/#{tutorial.id}")
+      expect(page).to have_content(tutorial.title)
       expect(page).to have_content("Successfully created tutorial.")
     end
   end


### PR DESCRIPTION
Admin can visit "/admin/tutorials/new", can add a new tutorial, (without a video) and is redirected to that Tutorial's show page. On that page, Admin can see the new tutorial, along with a message saying "Successfully created"